### PR TITLE
Add 0.12 tensforflow compatiblity

### DIFF
--- a/alexnet.py
+++ b/alexnet.py
@@ -16,14 +16,14 @@ def conv(input, kernel, biases, k_h, k_w, c_o, s_h, s_w,  padding="VALID", group
     if group == 1:
         conv = convolve(input, kernel)
     else:
-        if (tf.__version__ >= '0.12' ):
+        if (tf.__version__ > '0.12' ):
             input_groups = tf.split(input, group, 3)
             kernel_groups = tf.split(kernel, group, 3)
         else:
             input_groups = tf.split(3, group, input)
             kernel_groups = tf.split(3, group, kernel)
         output_groups = [convolve(i, k) for i, k in zip(input_groups, kernel_groups)]
-        if (tf.__version__ >= '0.12' ):
+        if (tf.__version__ > '0.12' ):
             conv = tf.concat(output_groups, 3)
         else:
             conv = tf.concat(3, output_groups)

--- a/alexnet.py
+++ b/alexnet.py
@@ -16,10 +16,18 @@ def conv(input, kernel, biases, k_h, k_w, c_o, s_h, s_w,  padding="VALID", group
     if group == 1:
         conv = convolve(input, kernel)
     else:
-        input_groups = tf.split(3, group, input)
-        kernel_groups = tf.split(3, group, kernel)
+        if (tf.__version__ >= '0.12' ):
+            input_groups = tf.split(input, group, 3)
+            kernel_groups = tf.split(kernel, group, 3)
+        else:
+            input_groups = tf.split(3, group, input)
+            kernel_groups = tf.split(3, group, kernel)
         output_groups = [convolve(i, k) for i, k in zip(input_groups, kernel_groups)]
-        conv = tf.concat(3, output_groups)
+        if (tf.__version__ >= '0.12' ):
+            conv = tf.concat(output_groups, 3)
+        else:
+            conv = tf.concat(3, output_groups)
+
     return tf.reshape(tf.nn.bias_add(conv, biases), [-1] + conv.get_shape().as_list()[1:])
 
 


### PR DESCRIPTION
-  since they changed arg ordering for tf.split and tf.concat to be more numpy-like according to:
https://github.com/tensorflow/tensorflow/issues/6501

If you guys have a better more pythonic solution please feel free to disregard this PR! I'm a noob in python so maybe theres a cooler way to version check here :sunglasses: : 

