### PR TITLE
add a requirements file, including Pillow dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ Before you start the lab, you should first install:
 * NumPy
 * SciPy
 * matplotlib
+* Pillow
+
+You can run `pip install -r requirements.txt` to install them all at once
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+tensorflow
+scipy
+matplotlib
+Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 tensorflow
+pandas
 scipy
+sklearn
 matplotlib
 Pillow


### PR DESCRIPTION
Pillow appears to be a required dependency
```
$ python imagenet_inference.py
Traceback (most recent call last):
  File "imagenet_inference.py", line 5, in <module>
    from scipy.misc import imread
ImportError: cannot import name 'imread'
```