### PR TITLE
fix for tensorflow 1.0.1 - ValueError: Only call  with named argument…

### DIFF
--- a/train_feature_extraction_solution.py
+++ b/train_feature_extraction_solution.py
@@ -29,7 +29,8 @@ fc8W = tf.Variable(tf.truncated_normal(shape, stddev=1e-2))
 fc8b = tf.Variable(tf.zeros(nb_classes))
 logits = tf.nn.xw_plus_b(fc7, fc8W, fc8b)
 
-cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(logits, labels)
+cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(logits = logits,
+        labels = labels)
 loss_op = tf.reduce_mean(cross_entropy)
 opt = tf.train.AdamOptimizer()
 train_op = opt.minimize(loss_op, var_list=[fc8W, fc8b])


### PR DESCRIPTION
Hi,

To fix the solution when running tensorflow 1.0.1. It's possible a comment in the code is better than the actual change since I don't know what other versions of tensorflow will be doing.
This was within the carnd-term1 environment but with tf upgraded to a gpu version.