### PR TITLE
scipy.misc.imread is gone, replace with matplotlib.pyplot.imread

### DIFF
--- a/imagenet_inference.py
+++ b/imagenet_inference.py
@@ -2,7 +2,7 @@
 import time
 import tensorflow as tf
 import numpy as np
-from scipy.misc import imread
+from matplotlib.pyplot import imread
 from caffe_classes import class_names
 from alexnet import AlexNet
 
@@ -19,10 +19,10 @@ sess = tf.Session()
 sess.run(init)
 
 # Read Images
-im1 = (imread("poodle.png")[:, :, :3]).astype(np.float32)
+im1 = (imread("poodle.png")[:, :, :3] * 255).astype(np.float32)
 im1 = im1 - np.mean(im1)
 
-im2 = (imread("weasel.png")[:, :, :3]).astype(np.float32)
+im2 = (imread("weasel.png")[:, :, :3] * 255).astype(np.float32)
 im2 = im2 - np.mean(im2)
 
 # Run Inference


### PR DESCRIPTION
In new 1.0.0 release of scipy (which is the current stable version as of Oct 25), `scipy.misc.imread` is gone (see the release notes: https://scipy.github.io/devdocs/release.1.0.0.html#deprecated-features).

I replaced it with `matplotlib.pyplot.imread` since `matplotlib` is already a dependency of several of the labs/projects. `pyplot`'s implementation has the quirk that it returns values in the range 0.0-1.0 instead of 0-255, so you need to scale the value by 255 before feeding it into the network.