### PR TITLE
Update train_feature_extraction_solution.py

### DIFF
--- a/train_feature_extraction_solution.py
+++ b/train_feature_extraction_solution.py
@@ -29,13 +29,13 @@ fc8W = tf.Variable(tf.truncated_normal(shape, stddev=1e-2))
 fc8b = tf.Variable(tf.zeros(nb_classes))
 logits = tf.nn.xw_plus_b(fc7, fc8W, fc8b)
 
-cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(logits, labels)
+cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(logits=logits, labels=labels)
 loss_op = tf.reduce_mean(cross_entropy)
 opt = tf.train.AdamOptimizer()
 train_op = opt.minimize(loss_op, var_list=[fc8W, fc8b])
 init_op = tf.global_variables_initializer()
 
-preds = tf.arg_max(logits, 1)
+preds = tf.argmax(logits, 1)
 accuracy_op = tf.reduce_mean(tf.cast(tf.equal(preds, labels), tf.float32))
 
 


### PR DESCRIPTION
1. ValueError: Only call sparse_softmax_cross_entropy_with_logits with named arguments (labels=..., logits=..., ...)
(logits, labels) -> logits = logits, labels = labels

2. WARNING:tensorflow:From train_feature_extraction.py:49: arg_max (from tensorflow.python.ops.gen_math_ops) is deprecated and will be removed in a future version.
Instructions for updating: Use argmax instead
arg_max -> argmax